### PR TITLE
fix(hero): add crossorigin to Cloudinary preload link

### DIFF
--- a/nuxt/components/hero.vue
+++ b/nuxt/components/hero.vue
@@ -172,6 +172,7 @@ export default {
             href: cloudinaryLink,
             rel: 'preload',
             as: 'image',
+            crossorigin: 'anonymous',
           },
         ],
       });


### PR DESCRIPTION
## Summary

One-line fix. The `<v-img>` component renders Cloudinary `<img>` tags with `crossorigin="anonymous"` ([v-img.vue:118](https://github.com/c4a8/c4a8-web-shared-components/blob/master/nuxt/components/v-img.vue#L118)). Without matching `crossorigin` on the `<link rel="preload">` in [`hero.vue`](https://github.com/c4a8/c4a8-web-shared-components/blob/master/nuxt/components/hero.vue) `preloadKeyAsset()`, the browser discards the preload ("A preload for ... is found, but is not used because the request credentials mode does not match") and re-fetches the image on the real `<img>` tag, hurting LCP at the upper percentiles.

Cloudflare Web Analytics on `www.terraprovider.com` showed LCP P75 = 3.3s / P99 = 14.7s with 19% of samples rated "Poor", strongly correlated with the duplicated hero-image fetch.

## Companion PR

[c4a8-web-terraprovider-com#38](https://github.com/c4a8/c4a8-web-terraprovider-com/pull/38) already applied the same fix to `content/hero.vue` in terraprovider (used by `@nuxt/content` for markdown-rendered heroes — blog etc.). That PR did not affect the homepage because `pages/index.vue` uses `<hero v-bind="heroData" />`, which resolves to the shared-components Hero — i.e. this file. This PR closes the gap.

Effect: every consuming GK product site (terraprovider, scepman, realmjoin, konnekt, …) that uses a Cloudinary-based hero will get the preload working on its next build.

## Test plan

After merge, on the next deploy of any consuming site:
- [ ] DevTools console: no more `A preload for '...' is found, but is not used because the request credentials mode does not match` warnings for hero images
- [ ] DevTools network: hero Cloudinary image loaded exactly once (not twice — preload + actual)
- [ ] Cloudflare Web Analytics: LCP P75/P99 should improve over the following days

🤖 Generated with [Claude Code](https://claude.com/claude-code)