### PR TITLE
fix(blog): apply sort before limit in shared-content-list

### DIFF
--- a/dist/runtime/components/shared-content-list.vue
+++ b/dist/runtime/components/shared-content-list.vue
@@ -66,6 +66,14 @@ const buildQuery = (collectionName) => {
     });
   }
 
+  if (Array.isArray(lQuery.sort)) {
+    lQuery.sort.forEach((sortItem) => {
+      Object.entries(sortItem).forEach(([field, direction]) => {
+        queryBuilder = queryBuilder.order(field, direction === 1 ? 'ASC' : 'DESC');
+      });
+    });
+  }
+
   if (lQuery.limit) {
     queryBuilder = queryBuilder.limit(lQuery.limit);
   }

--- a/nuxt/components/shared-content-list.vue
+++ b/nuxt/components/shared-content-list.vue
@@ -66,6 +66,14 @@ const buildQuery = (collectionName) => {
     });
   }
 
+  if (Array.isArray(lQuery.sort)) {
+    lQuery.sort.forEach((sortItem) => {
+      Object.entries(sortItem).forEach(([field, direction]) => {
+        queryBuilder = queryBuilder.order(field, direction === 1 ? 'ASC' : 'DESC');
+      });
+    });
+  }
+
   if (lQuery.limit) {
     queryBuilder = queryBuilder.limit(lQuery.limit);
   }


### PR DESCRIPTION
## Summary
- The query builder in `shared-content-list.vue` applied `.limit()` without first calling `.order()`. Nuxt Content returned the first N items by default path order (oldest dates first, since post filenames start with `YYYY-MM-DD`), and the client-side sort then ran on that truncated subset.
- Visible on locales with more posts than the configured `maxBlogPosts` (default 100). The DE blog index cut off at 2025-03 while the EN blog (fewer posts) looked fine.
- Fix: translate the existing `query.sort` array into `.order(field, dir)` calls on the query builder before applying `.limit()`. The database sorts the full collection and only then truncates.